### PR TITLE
Skip special devices

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -132,7 +132,7 @@ fn main() -> Result<()> {
 
                     if should_delete {
                         info!("Deleting {:?} at {:?}", names, path);
-                        if let Err(err) = utils::ensure_deleted(&path) {
+                        if let Err(err) = utils::ensure_deleted(path) {
                             error!("Failed to delete {:?}: {:#}", path, err);
                         } else {
                             deleted.push(path.clone());


### PR DESCRIPTION
Only actual files should be opened. Directories are logged but walkdir already traverses them on its own so we're can safely skip them too.

Resolves #8